### PR TITLE
Fix StartsWith/EndsWith equality check

### DIFF
--- a/core/src/datamatrix/DMHighLevelEncoder.cpp
+++ b/core/src/datamatrix/DMHighLevelEncoder.cpp
@@ -843,12 +843,12 @@ namespace Base256Encoder {
 //TODO: c++20
 static bool StartsWith(std::wstring_view s, std::wstring_view ss)
 {
-	return s.length() > ss.length() && s.compare(0, ss.length(), ss) == 0;
+        return s.length() >= ss.length() && s.compare(0, ss.length(), ss) == 0;
 }
 
 static bool EndsWith(std::wstring_view s, std::wstring_view ss)
 {
-	return s.length() > ss.length() && s.compare(s.length() - ss.length(), ss.length(), ss) == 0;
+        return s.length() >= ss.length() && s.compare(s.length() - ss.length(), ss.length(), ss) == 0;
 }
 
 ByteArray Encode(const std::wstring& msg)


### PR DESCRIPTION
## Summary
- fix `StartsWith`/`EndsWith` check in `DMHighLevelEncoder`

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DZXING_UNIT_TESTS=ON -DZXING_BLACKBOX_TESTS=OFF -DZXING_EXAMPLES=OFF` *(fails: unable to fetch googletest)*

------
https://chatgpt.com/codex/tasks/task_e_686cc5bb4454832cbc27fc8c3c55ed15